### PR TITLE
Move relay to port 5333 to avoid collisions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,7 @@ runs:
         set -euo pipefail
         exec /opt/relay/relay run \
             --mode=proxy \
+            --port=5333 \
             --shutdown-timeout=2 \
             --upstream-dsn="\$SENTRY_DSN" \
             --aws-runtime-api="\$AWS_LAMBDA_RUNTIME_API"


### PR DESCRIPTION
related to https://github.com/getsentry/sentry-javascript/pull/6093
and https://github.com/getsentry/sentry-python/pull/1716
